### PR TITLE
feat(header): add header default and reuse button component

### DIFF
--- a/src/app/core/components-core/components-core.module.ts
+++ b/src/app/core/components-core/components-core.module.ts
@@ -1,8 +1,11 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { HeaderComponent } from './header/header.component';
+import { FormsModule } from '../../shared/components/forms/forms.module';
 
 @NgModule({
-  declarations: [],
-  imports: [CommonModule],
+  declarations: [HeaderComponent],
+  exports: [HeaderComponent],
+  imports: [CommonModule, FormsModule],
 })
 export class ComponentsCoreModule {}

--- a/src/app/core/components-core/header/header.component.html
+++ b/src/app/core/components-core/header/header.component.html
@@ -1,0 +1,4 @@
+<header>
+  <app-button type="text" [showIcon]="true" typeIcon="backIcon" (buttonClick)="goBack()"></app-button>
+  <h2>{{ title }}</h2>
+</header>

--- a/src/app/core/components-core/header/header.component.html
+++ b/src/app/core/components-core/header/header.component.html
@@ -1,4 +1,4 @@
 <header>
-  <app-button type="text" [showIcon]="true" typeIcon="backIcon" (buttonClick)="goBack()"></app-button>
+  <app-button type="text" codeIcon="majesticons:arrow-left-line" (buttonClick)="goBack()"></app-button>
   <h2>{{ title }}</h2>
 </header>

--- a/src/app/core/components-core/header/header.component.scss
+++ b/src/app/core/components-core/header/header.component.scss
@@ -1,0 +1,22 @@
+@import '../../../../styles/mixins';
+
+header {
+  height: 48px;
+  @include applyGrid(row, 1, 0, 1fr);
+
+  app-button {
+    grid-column: 1 / 2;
+    align-self: center;
+    margin-top: 48px;
+    margin-left: 4px;
+  }
+
+  h2 {
+    grid-column: 1 / -1;
+    justify-self: center;
+    align-self: center;
+    font-size: 1.5rem;
+    margin: 0;
+    text-align: center;
+  }
+}

--- a/src/app/core/components-core/header/header.component.spec.ts
+++ b/src/app/core/components-core/header/header.component.spec.ts
@@ -1,0 +1,22 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { HeaderComponent } from './header.component';
+
+describe('HeaderComponent', () => {
+  let component: HeaderComponent;
+  let fixture: ComponentFixture<HeaderComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [HeaderComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(HeaderComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/core/components-core/header/header.component.ts
+++ b/src/app/core/components-core/header/header.component.ts
@@ -1,0 +1,45 @@
+import { Component, Input } from '@angular/core';
+import { Location } from '@angular/common';
+
+/**
+ * Componente de Header da aplicação.
+ * Exibe o título da página e um botão de voltar para a página anterior.
+ *
+ * @component
+ */
+@Component({
+  selector: 'app-header',
+  templateUrl: './header.component.html',
+  styleUrls: ['./header.component.scss'],
+})
+export class HeaderComponent {
+  /**
+   * Título a ser exibido no Header.
+   * Este título pode ser definido pelo componente pai através da propriedade `@Input()`.
+   * O valor padrão é 'Título do Header'.
+   *
+   * @type {string}
+   * @default 'Título do Header'
+   */
+  @Input() title: string = 'Título do Header';
+
+  /**
+   * Construtor do componente Header.
+   * Injeta o serviço `Location` para permitir navegação de volta.
+   *
+   * @param {Location} location - Serviço usado para navegar na história do navegador.
+   */
+  constructor(private location: Location) {}
+
+  /**
+   * Método para voltar à página anterior.
+   * Esse método é invocado quando o usuário clica no botão de voltar.
+   * Ele chama o método `back()` do serviço `Location` para voltar na navegação anterior do navegador.
+   *
+   * @returns {void}
+   */
+  goBack(): void {
+    this.location.back();
+    console.log('Botão Clicado');
+  }
+}

--- a/src/app/core/components-core/header/header.component.ts
+++ b/src/app/core/components-core/header/header.component.ts
@@ -23,12 +23,6 @@ export class HeaderComponent {
    */
   @Input() title: string = 'Título do Header';
 
-  /**
-   * Construtor do componente Header.
-   * Injeta o serviço `Location` para permitir navegação de volta.
-   *
-   * @param {Location} location - Serviço usado para navegar na história do navegador.
-   */
   constructor(private location: Location) {}
 
   /**

--- a/src/app/shared/components/forms/button/button.component.html
+++ b/src/app/shared/components/forms/button/button.component.html
@@ -1,45 +1,11 @@
 <button [ngClass]="getButtonClass()" [disabled]="disabled" (click)="onClick()">
-  <ng-container *ngIf="showIcon">
-    <svg
-      *ngIf="typeIcon === 'addIcon'"
-      xmlns="http://www.w3.org/2000/svg"
-      [attr.width]="isOnlyIcon ? '24' : '18'"
-      [attr.height]="isOnlyIcon ? '24' : '18'"
-      viewBox="0 0 24 24"
-      fill="none"
-      [ngStyle]="{ color: getIconColor(), stroke: getIconColor() }">
-      <path
-        d="M12 4.5V19.5M19.5 12L4.5 12"
-        stroke="currentColor"
-        stroke-width="1.5"
-        stroke-linecap="round"
-        stroke-linejoin="round" />
-    </svg>
-    <svg
-      *ngIf="typeIcon === 'backIcon'"
-      xmlns="http://www.w3.org/2000/svg"
-      [attr.width]="isOnlyIcon ? '24' : '18'"
-      [attr.height]="isOnlyIcon ? '24' : '18'"
-      viewBox="0 0 24 24"
-      fill="none">
-      <path d="M7.825 13L13.425 18.6L12 20L4 12L12 4L13.425 5.4L7.825 11H20V13H7.825Z" fill="#1D1D1D" />
-    </svg>
-    <svg
-      *ngIf="typeIcon === 'linkUpIcon'"
-      xmlns="http://www.w3.org/2000/svg"
-      [attr.width]="isOnlyIcon ? '24' : '18'"
-      [attr.height]="isOnlyIcon ? '24' : '18'"
-      viewBox="0 0 19 18"
-      fill="none">
-      <mask id="mask0_948_8011" style="mask-type: alpha" maskUnits="userSpaceOnUse" x="0" y="0" width="19" height="18">
-        <rect x="0.5" width="18" height="18" fill="#D9D9D9" />
-      </mask>
-      <g mask="url(#mask0_948_8011)">
-        <path
-          d="M8.75 12.75H5.75C4.7125 12.75 3.82812 12.3844 3.09687 11.6531C2.36562 10.9219 2 10.0375 2 9C2 7.9625 2.36562 7.07812 3.09687 6.34687C3.82812 5.61562 4.7125 5.25 5.75 5.25H8.75V6.75H5.75C5.125 6.75 4.59375 6.96875 4.15625 7.40625C3.71875 7.84375 3.5 8.375 3.5 9C3.5 9.625 3.71875 10.1562 4.15625 10.5938C4.59375 11.0312 5.125 11.25 5.75 11.25H8.75V12.75ZM6.5 9.75V8.25H12.5V9.75H6.5ZM10.25 12.75V11.25H13.25C13.875 11.25 14.4062 11.0312 14.8438 10.5938C15.2812 10.1562 15.5 9.625 15.5 9C15.5 8.375 15.2812 7.84375 14.8438 7.40625C14.4062 6.96875 13.875 6.75 13.25 6.75H10.25V5.25H13.25C14.2875 5.25 15.1719 5.61562 15.9031 6.34687C16.6344 7.07812 17 7.9625 17 9C17 10.0375 16.6344 10.9219 15.9031 11.6531C15.1719 12.3844 14.2875 12.75 13.25 12.75H10.25Z"
-          fill="#F1F4F5" />
-      </g>
-    </svg>
+  <ng-container *ngIf="codeIcon">
+    <img
+      [src]="codeIcon"
+      [alt]="label || 'button icon'"
+      [attr.width]="isIconOnly ? '24' : '18'"
+      [attr.height]="isIconOnly ? '24' : '18'"
+      [ngStyle]="{ color: getIconColor(), stroke: getIconColor() }" />
   </ng-container>
   <span *ngIf="label" [ngStyle]="{ color: getLabelColor() }">{{ label }}</span>
 </button>

--- a/src/app/shared/components/forms/button/button.component.html
+++ b/src/app/shared/components/forms/button/button.component.html
@@ -1,18 +1,45 @@
 <button [ngClass]="getButtonClass()" [disabled]="disabled" (click)="onClick()">
-  <svg
-    *ngIf="showIcon"
-    xmlns="http://www.w3.org/2000/svg"
-    [attr.width]="isOnlyIcon ? '24' : '18'"
-    [attr.height]="isOnlyIcon ? '24' : '18'"
-    viewBox="0 0 24 24"
-    fill="none"
-    [ngStyle]="{ color: getIconColor(), stroke: getIconColor() }">
-    <path
-      d="M12 4.5V19.5M19.5 12L4.5 12"
-      stroke="currentColor"
-      stroke-width="1.5"
-      stroke-linecap="round"
-      stroke-linejoin="round" />
-  </svg>
+  <ng-container *ngIf="showIcon">
+    <svg
+      *ngIf="typeIcon === 'addIcon'"
+      xmlns="http://www.w3.org/2000/svg"
+      [attr.width]="isOnlyIcon ? '24' : '18'"
+      [attr.height]="isOnlyIcon ? '24' : '18'"
+      viewBox="0 0 24 24"
+      fill="none"
+      [ngStyle]="{ color: getIconColor(), stroke: getIconColor() }">
+      <path
+        d="M12 4.5V19.5M19.5 12L4.5 12"
+        stroke="currentColor"
+        stroke-width="1.5"
+        stroke-linecap="round"
+        stroke-linejoin="round" />
+    </svg>
+    <svg
+      *ngIf="typeIcon === 'backIcon'"
+      xmlns="http://www.w3.org/2000/svg"
+      [attr.width]="isOnlyIcon ? '24' : '18'"
+      [attr.height]="isOnlyIcon ? '24' : '18'"
+      viewBox="0 0 24 24"
+      fill="none">
+      <path d="M7.825 13L13.425 18.6L12 20L4 12L12 4L13.425 5.4L7.825 11H20V13H7.825Z" fill="#1D1D1D" />
+    </svg>
+    <svg
+      *ngIf="typeIcon === 'linkUpIcon'"
+      xmlns="http://www.w3.org/2000/svg"
+      [attr.width]="isOnlyIcon ? '24' : '18'"
+      [attr.height]="isOnlyIcon ? '24' : '18'"
+      viewBox="0 0 19 18"
+      fill="none">
+      <mask id="mask0_948_8011" style="mask-type: alpha" maskUnits="userSpaceOnUse" x="0" y="0" width="19" height="18">
+        <rect x="0.5" width="18" height="18" fill="#D9D9D9" />
+      </mask>
+      <g mask="url(#mask0_948_8011)">
+        <path
+          d="M8.75 12.75H5.75C4.7125 12.75 3.82812 12.3844 3.09687 11.6531C2.36562 10.9219 2 10.0375 2 9C2 7.9625 2.36562 7.07812 3.09687 6.34687C3.82812 5.61562 4.7125 5.25 5.75 5.25H8.75V6.75H5.75C5.125 6.75 4.59375 6.96875 4.15625 7.40625C3.71875 7.84375 3.5 8.375 3.5 9C3.5 9.625 3.71875 10.1562 4.15625 10.5938C4.59375 11.0312 5.125 11.25 5.75 11.25H8.75V12.75ZM6.5 9.75V8.25H12.5V9.75H6.5ZM10.25 12.75V11.25H13.25C13.875 11.25 14.4062 11.0312 14.8438 10.5938C15.2812 10.1562 15.5 9.625 15.5 9C15.5 8.375 15.2812 7.84375 14.8438 7.40625C14.4062 6.96875 13.875 6.75 13.25 6.75H10.25V5.25H13.25C14.2875 5.25 15.1719 5.61562 15.9031 6.34687C16.6344 7.07812 17 7.9625 17 9C17 10.0375 16.6344 10.9219 15.9031 11.6531C15.1719 12.3844 14.2875 12.75 13.25 12.75H10.25Z"
+          fill="#F1F4F5" />
+      </g>
+    </svg>
+  </ng-container>
   <span *ngIf="label" [ngStyle]="{ color: getLabelColor() }">{{ label }}</span>
 </button>

--- a/src/app/shared/components/forms/button/button.component.ts
+++ b/src/app/shared/components/forms/button/button.component.ts
@@ -7,15 +7,14 @@ import { Component, Input, Output, EventEmitter } from '@angular/core';
 })
 export class ButtonComponent {
   @Input() type: 'filled' | 'outlined' | 'text' = 'filled';
-  @Input() showIcon: boolean = false;
-  @Input() typeIcon: 'addIcon' | 'backIcon' | 'linkUpIcon' = 'addIcon';
+  @Input() codeIcon: string | null = null;
   @Input() label: string = '';
   @Input() disabled: boolean = false;
 
   @Output() buttonClick = new EventEmitter<void>();
 
   /**
-   * Retorna as classes CSS do botão baseadas no tipo e no estado de desabilitação.
+   * Retorna as classes CSS do botão com base no tipo e estado.
    *
    * @returns {string} As classes CSS do botão.
    */
@@ -24,8 +23,8 @@ export class ButtonComponent {
     if (this.disabled) {
       baseClass += ' disabled';
     }
-    if (this.showIcon && !this.label) {
-      baseClass += ' only-icon'; // Adiciona a classe only-icon quando só há ícone
+    if (this.isIconOnly) {
+      baseClass += ' only-icon';
     }
     return baseClass;
   }
@@ -35,30 +34,42 @@ export class ButtonComponent {
    *
    * @returns {void}
    */
-  onClick() {
+  onClick(): void {
     if (!this.disabled) {
-      this.buttonClick.emit(); // Emite o evento de clique
+      this.buttonClick.emit();
     }
   }
 
-  // Lógica para verificar se o botão tem apenas o ícone
-  get isOnlyIcon(): boolean {
-    return this.showIcon && !this.label;
+  /**
+   * Verifica se o botão deve ser renderizado como apenas um ícone.
+   *
+   * @returns {boolean} Verdadeiro se o botão possui apenas o ícone e nenhuma label.
+   */
+  get isIconOnly(): boolean {
+    return this.codeIcon !== null && !this.label;
   }
 
-  // Método para retornar a cor do ícone
+  /**
+   * Retorna a cor apropriada para o ícone baseado no tipo do botão.
+   *
+   * @returns {string} A cor do ícone.
+   */
   getIconColor(): string {
     if (this.type === 'outlined' || this.type === 'text') {
       return 'var(--normal)';
     }
-    return ''; // Caso contrário, usa o valor padrão da classe
+    return '';
   }
 
-  // Método para retornar a cor da label
+  /**
+   * Retorna a cor apropriada para o texto da label baseado no tipo do botão.
+   *
+   * @returns {string} A cor da label.
+   */
   getLabelColor(): string {
     if (this.type === 'outlined' || this.type === 'text') {
       return 'var(--normal)';
     }
-    return ''; // Caso contrário, usa o valor padrão da classe
+    return '';
   }
 }

--- a/src/app/shared/components/forms/button/button.component.ts
+++ b/src/app/shared/components/forms/button/button.component.ts
@@ -8,6 +8,7 @@ import { Component, Input, Output, EventEmitter } from '@angular/core';
 export class ButtonComponent {
   @Input() type: 'filled' | 'outlined' | 'text' = 'filled';
   @Input() showIcon: boolean = false;
+  @Input() typeIcon: 'addIcon' | 'backIcon' | 'linkUpIcon' = 'addIcon';
   @Input() label: string = '';
   @Input() disabled: boolean = false;
 


### PR DESCRIPTION
# Título da Merge Request

**Adiciona componente de Header com botão reutilizável e funcionalidade de navegação para a página anterior**

---

## Descrição

Essa MR adiciona o componente `Header` à aplicação, com um botão reutilizável integrado. O botão agora é capaz de renderizar diferentes ícones com base nas propriedades passadas e foi configurado para navegar de volta à página anterior. A funcionalidade de navegação foi implementada utilizando o serviço `Location` do Angular. Além disso, o título do `Header` pode ser personalizado a partir do componente pai.

---

## Issue ou Card Relacionado

-https://trello.com/c/gz2nf3xP/39-component-header-core 

---

## Passos para Testar

1. **Verifique o Componente de Header:**
   - Certifique-se de que o componente `Header` está sendo renderizado corretamente.
   - O título exibido deve ser o valor fornecido pelo componente pai, ou o valor padrão, "Título do Header", caso não seja fornecido.

2. **Teste de Responsividade:**
   - Verifique se o layout do componente `Header` está correto e responsivo. O título deve ser centralizado, e o botão de voltar deve ser posicionado corretamente à esquerda.

---

## Checklist

- [x] A funcionalidade foi testada manualmente.
- [x] O código segue as boas práticas definidas.
- [x] Revisei as dependências e possíveis impactos no código existente.

---
