### PR TITLE
feat(component): add classcard-title component

### DIFF
--- a/src/app/core/services/date-capture/date-capture.variables.ts
+++ b/src/app/core/services/date-capture/date-capture.variables.ts
@@ -12,6 +12,6 @@ export const MONTHS_FULL = [
   'outubro',
   'novembro',
   'dezembro',
-];
+] as const;
 
 export const MONTHS_ABBREVIATED = MONTHS_FULL.map((month) => month.substring(0, 3));

--- a/src/app/shared/components/display/classcard-title/classcard-title.component.html
+++ b/src/app/shared/components/display/classcard-title/classcard-title.component.html
@@ -1,0 +1,3 @@
+<section class="container">
+  <h2>TURMA: {{ schoolClass }} - {{ subject }}</h2>
+</section>

--- a/src/app/shared/components/display/classcard-title/classcard-title.component.scss
+++ b/src/app/shared/components/display/classcard-title/classcard-title.component.scss
@@ -1,0 +1,29 @@
+body {
+  position: relative;
+  height: 100vh;
+  margin: 0;
+}
+
+.container {
+  position: absolute;
+  left: 50%;
+  top: 150px;
+  transform: translate(-50%, -50%);
+  display: flex;
+  width: 344px;
+  height: 56px;
+  padding: 18px 27px;
+  justify-content: center;
+  align-items: center;
+  gap: 10px;
+  background-color: var(--normal);
+  border-radius: 10px;
+
+  h2 {
+    color: var(--white);
+    font-size: 19px;
+    font-weight: 600;
+    line-height: 22px;
+    text-align: center;
+  }
+}

--- a/src/app/shared/components/display/classcard-title/classcard-title.component.spec.ts
+++ b/src/app/shared/components/display/classcard-title/classcard-title.component.spec.ts
@@ -1,0 +1,22 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ClasscardTitleComponent } from './classcard-title.component';
+
+describe('ClasscardTitleComponent', () => {
+  let component: ClasscardTitleComponent;
+  let fixture: ComponentFixture<ClasscardTitleComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ClasscardTitleComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ClasscardTitleComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/shared/components/display/classcard-title/classcard-title.component.ts
+++ b/src/app/shared/components/display/classcard-title/classcard-title.component.ts
@@ -1,0 +1,11 @@
+import { Component, Input } from '@angular/core';
+
+@Component({
+  selector: 'app-classcard-title',
+  templateUrl: './classcard-title.component.html',
+  styleUrl: './classcard-title.component.scss',
+})
+export class ClasscardTitleComponent {
+  @Input() schoolClass: string = '';
+  @Input() subject: string = '';
+}

--- a/src/app/shared/components/display/display.module.ts
+++ b/src/app/shared/components/display/display.module.ts
@@ -3,10 +3,11 @@ import { CommonModule } from '@angular/common';
 import { ModalComponent } from './modal/modal.component';
 import { FormsModule } from '../forms/forms.module';
 import { SubheaderComponent } from './subheader/subheader.component';
+import { ClasscardTitleComponent } from './classcard-title/classcard-title.component';
 
 @NgModule({
-  declarations: [ModalComponent, SubheaderComponent],
-  exports: [ModalComponent, SubheaderComponent],
+  declarations: [ModalComponent, SubheaderComponent, ClasscardTitleComponent],
+  exports: [ModalComponent, SubheaderComponent, ClasscardTitleComponent],
   imports: [CommonModule, FormsModule],
 })
 export class DisplayModule {}


### PR DESCRIPTION
**Título da Merge Request:**  
Adiciona componente de exibição de turma e disciplina

**Descrição:**  
Essa MR adiciona um componente para exibir informações de turma e disciplina em um layout centralizado e responsivo. O componente utiliza variáveis para personalizar os dados exibidos (`schoolClass` e `subject`) e segue um design simples com cores e tipografia consistentes.

**Passos para Testar:**  
1. Renderize o componente em uma página usando valores para `schoolClass` e `subject`.  
2. Verifique se ele está centralizado no eixo X. 
3. Teste em diferentes tamanhos de tela para garantir que o layout permanece responsivo.  

**Checklist:**  
- [x] A funcionalidade foi testada manualmente.  
- [x] O código segue as boas práticas definidas.  
- [x] Revisei as dependências e possíveis impactos no código existente.  
