### PR TITLE
feat(not-found): add 404 not found page

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -7,6 +7,7 @@ const routes: Routes = [
   { path: 'welcome', loadChildren: () => import('./pages/welcome/welcome.module').then((m) => m.WelcomeModule) },
   { path: 'login', loadChildren: () => import('./pages/login/login.module').then((m) => m.LoginModule) },
   { path: 'register', loadChildren: () => import('./pages/register/register.module').then((m) => m.RegisterModule) },
+  { path: 'invite/:id', loadChildren: () => import('./pages/not-found/not-found.module').then((m) => m.NotFoundModule) },
   { path: '**', loadChildren: () => import('./pages/not-found/not-found.module').then((m) => m.NotFoundModule) },
 ];
 

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -3,15 +3,12 @@ import { BrowserModule } from '@angular/platform-browser';
 import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
 import { NotFoundComponent } from './pages/not-found/not-found.component';
+import { FormsModule } from './shared/components/forms/forms.module';
 // import { NavbarModule } from './shared/components/navbar/navbar.module';
 
 @NgModule({
   declarations: [AppComponent, NotFoundComponent],
-  imports: [
-    BrowserModule,
-    AppRoutingModule,
-    // ,NavbarModule
-  ],
+  imports: [BrowserModule, AppRoutingModule, FormsModule],
   providers: [],
   bootstrap: [AppComponent],
 })

--- a/src/app/pages/not-found/not-found.component.html
+++ b/src/app/pages/not-found/not-found.component.html
@@ -1,8 +1,8 @@
 <section class="container">
   <img src="../../../assets/img/kognito.png" alt="kognito" />
   <div class="message">
-    <h2>{{ errorTitle }}</h2>
-    <p>{{ errorMessage }}</p>
+    <h2>Ocorreu um erro de sistema 404</h2>
+    <p>Por favor, tente novamente mais tarde.</p>
   </div>
 
   <app-button type="filled" label="Voltar para a tela inicial" (click)="goToHome()"></app-button>

--- a/src/app/pages/not-found/not-found.component.html
+++ b/src/app/pages/not-found/not-found.component.html
@@ -1,1 +1,16 @@
-<p>not-found works!</p>
+<section class="container">
+  <img src="../../../assets/img/kognito.png" alt="kognito" />
+  <div class="message">
+    <h2 *ngIf="isTeacherRoute; else studentMessage">Ocorreu um erro de sistema 404</h2>
+    <p *ngIf="isTeacherRoute; else studentParagraph">Por favor, tente novamente mais tarde.</p>
+
+    <ng-template #studentMessage>
+      <h2>Link de convite indisponível</h2>
+    </ng-template>
+    <ng-template #studentParagraph>
+      <p>Por favor, tente novamente mais tarde, ou solicite um novo link ao professor.</p>
+    </ng-template>
+  </div>
+
+  <app-button type="filled" label="Voltar para a tela inicial" (click)="goToHome()"></app-button>
+</section>

--- a/src/app/pages/not-found/not-found.component.html
+++ b/src/app/pages/not-found/not-found.component.html
@@ -1,15 +1,8 @@
 <section class="container">
   <img src="../../../assets/img/kognito.png" alt="kognito" />
   <div class="message">
-    <h2 *ngIf="isTeacherRoute; else studentMessage">Ocorreu um erro de sistema 404</h2>
-    <p *ngIf="isTeacherRoute; else studentParagraph">Por favor, tente novamente mais tarde.</p>
-
-    <ng-template #studentMessage>
-      <h2>Link de convite indisponível</h2>
-    </ng-template>
-    <ng-template #studentParagraph>
-      <p>Por favor, tente novamente mais tarde, ou solicite um novo link ao professor.</p>
-    </ng-template>
+    <h2>{{ errorTitle }}</h2>
+    <p>{{ errorMessage }}</p>
   </div>
 
   <app-button type="filled" label="Voltar para a tela inicial" (click)="goToHome()"></app-button>

--- a/src/app/pages/not-found/not-found.component.scss
+++ b/src/app/pages/not-found/not-found.component.scss
@@ -1,0 +1,38 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  position: relative;
+  top: 115px;
+}
+
+img {
+  width: 276px;
+  height: 276px;
+}
+
+.message {
+  margin-top: 32px;
+  text-align: center;
+  color: var(--black);
+}
+
+.message h2 {
+  font-size: 20px;
+  font-style: normal;
+  font-weight: 600;
+  line-height: 22px;
+}
+
+.message p {
+  margin-top: 30px;
+  font-size: 16px;
+  font-style: normal;
+  font-weight: 400;
+  line-height: 150%;
+}
+
+app-button {
+  margin-top: 140px;
+}

--- a/src/app/pages/not-found/not-found.component.scss
+++ b/src/app/pages/not-found/not-found.component.scss
@@ -1,38 +1,52 @@
 .container {
-  display: flex;
-  flex-direction: column;
+  display: grid;
+  grid-template-columns: 1fr;
   justify-content: center;
   align-items: center;
+  gap: 32px;
   position: relative;
-  top: 115px;
+  top: 10vh;
+  padding: 16px;
+  max-width: 100%;
+  box-sizing: border-box;
 }
 
 img {
-  width: 276px;
-  height: 276px;
+  width: 100%;
+  max-width: 276px;
+  height: auto;
+  justify-self: center;
 }
 
 .message {
-  margin-top: 32px;
   text-align: center;
   color: var(--black);
-}
-
-.message h2 {
-  font-size: 20px;
-  font-style: normal;
-  font-weight: 600;
-  line-height: 22px;
-}
-
-.message p {
-  margin-top: 30px;
-  font-size: 16px;
-  font-style: normal;
-  font-weight: 400;
-  line-height: 150%;
+  display: grid;
+  gap: 16px;
+  h2 {
+    font-size: clamp(16px, 5vw, 20px);
+    font-style: normal;
+    font-weight: 600;
+    line-height: 1.2;
+  }
+  p {
+    font-size: clamp(14px, 4vw, 16px);
+    font-style: normal;
+    font-weight: 400;
+    line-height: 1.5;
+  }
 }
 
 app-button {
-  margin-top: 140px;
+  display: flex;
+  justify-content: center;
+  position: relative;
+  bottom: -10vh;
+  max-width: 100%;
+  padding: 8px 16px;
+  box-sizing: border-box;
+}
+
+.container {
+  grid-template-columns: minmax(0, 1fr);
 }

--- a/src/app/pages/not-found/not-found.component.ts
+++ b/src/app/pages/not-found/not-found.component.ts
@@ -1,8 +1,28 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
 
 @Component({
   selector: 'app-not-found',
   templateUrl: './not-found.component.html',
-  styleUrl: './not-found.component.scss',
+  styleUrls: ['./not-found.component.scss'],
 })
-export class NotFoundComponent {}
+export class NotFoundComponent implements OnInit {
+  isTeacherRoute: boolean = false; // Flag para verificar o contexto
+
+  constructor(private activatedRoute: ActivatedRoute) {}
+
+  /**
+   * Método do ciclo de vida do Angular chamado após a criação do componente.
+   * Verifica se a rota contém "teacher" para ajustar o contexto.
+   */
+  ngOnInit(): void {
+    this.isTeacherRoute = this.activatedRoute.snapshot.url.some((segment) => segment.path.includes('teacher'));
+  }
+
+  /**
+   * Redireciona o usuário para a página inicial (rota "/").
+   */
+  goToHome(): void {
+    window.location.href = '/';
+  }
+}

--- a/src/app/pages/not-found/not-found.component.ts
+++ b/src/app/pages/not-found/not-found.component.ts
@@ -1,32 +1,35 @@
 import { Component, OnInit } from '@angular/core';
-import { ActivatedRoute } from '@angular/router';
+import { Router } from '@angular/router';
 
+/**
+ * Componente responsável por exibir a página de "Não Encontrado" (404)
+ * e redirecionar o usuário para a página inicial, se necessário.
+ */
 @Component({
   selector: 'app-not-found',
   templateUrl: './not-found.component.html',
   styleUrls: ['./not-found.component.scss'],
 })
 export class NotFoundComponent implements OnInit {
-  errorTitle: string = 'Ocorreu um erro de sistema 404';
-  errorMessage: string = 'Por favor, tente novamente mais tarde.';
-
-  constructor(private route: ActivatedRoute) {}
+  constructor(private router: Router) {}
 
   /**
-   * Verifica os parâmetros da rota e ajusta as mensagens de erro, caso seja um link de convite inválido.
+   * Método de ciclo de vida do Angular chamado ao inicializar o componente.
+   *
+   * Atualmente, lança um erro porque o método ainda não foi implementado.
+   *
+   * @throws Error - Método não implementado.
    */
   ngOnInit(): void {
-    const linkType = this.route.snapshot.queryParams['type'];
-    if (linkType === 'invite') {
-      this.errorTitle = 'Link de convite indisponível';
-      this.errorMessage = 'Por favor, tente novamente mais tarde, ou solicite um novo link ao professor.';
-    }
+    throw new Error('Method not implemented.');
   }
 
   /**
    * Redireciona o usuário para a página inicial da aplicação.
+   *
+   * @returns void
    */
   goToHome(): void {
-    window.location.href = '/';
+    this.router.navigate(['/']);
   }
 }

--- a/src/app/pages/not-found/not-found.component.ts
+++ b/src/app/pages/not-found/not-found.component.ts
@@ -12,8 +12,10 @@ export class NotFoundComponent implements OnInit {
 
   constructor(private route: ActivatedRoute) {}
 
+  /**
+   * Verifica os parâmetros da rota e ajusta as mensagens de erro, caso seja um link de convite inválido.
+   */
   ngOnInit(): void {
-    // Verifica se a URL contém o "convite" na rota
     const linkType = this.route.snapshot.queryParams['type'];
     if (linkType === 'invite') {
       this.errorTitle = 'Link de convite indisponível';
@@ -21,7 +23,10 @@ export class NotFoundComponent implements OnInit {
     }
   }
 
+  /**
+   * Redireciona o usuário para a página inicial da aplicação.
+   */
   goToHome(): void {
-    window.location.href = '/'; // Redireciona para a página inicial
+    window.location.href = '/';
   }
 }

--- a/src/app/pages/not-found/not-found.component.ts
+++ b/src/app/pages/not-found/not-found.component.ts
@@ -7,22 +7,21 @@ import { ActivatedRoute } from '@angular/router';
   styleUrls: ['./not-found.component.scss'],
 })
 export class NotFoundComponent implements OnInit {
-  isTeacherRoute: boolean = false; // Flag para verificar o contexto
+  errorTitle: string = 'Ocorreu um erro de sistema 404';
+  errorMessage: string = 'Por favor, tente novamente mais tarde.';
 
-  constructor(private activatedRoute: ActivatedRoute) {}
+  constructor(private route: ActivatedRoute) {}
 
-  /**
-   * Método do ciclo de vida do Angular chamado após a criação do componente.
-   * Verifica se a rota contém "teacher" para ajustar o contexto.
-   */
   ngOnInit(): void {
-    this.isTeacherRoute = this.activatedRoute.snapshot.url.some((segment) => segment.path.includes('teacher'));
+    // Verifica se a URL contém o "convite" na rota
+    const linkType = this.route.snapshot.queryParams['type'];
+    if (linkType === 'invite') {
+      this.errorTitle = 'Link de convite indisponível';
+      this.errorMessage = 'Por favor, tente novamente mais tarde, ou solicite um novo link ao professor.';
+    }
   }
 
-  /**
-   * Redireciona o usuário para a página inicial (rota "/").
-   */
   goToHome(): void {
-    window.location.href = '/';
+    window.location.href = '/'; // Redireciona para a página inicial
   }
 }


### PR DESCRIPTION
# Título da Merge Request

Adiciona lógica dinâmica para exibição de mensagens na página "Not Found"

## Descrição

Essa MR implementa uma lógica dinâmica para a página "Not Found", alterando o conteúdo exibido com base na rota atual. Agora, se a rota contiver "teacher", a mensagem exibida será voltada para professores; caso contrário, será exibida uma mensagem específica para estudantes.

Também foi implementado um botão que redireciona o usuário para a página inicial.

## Issue ou Card Relacionado

- https://trello.com/c/3jNqCh1Z/83-tela-404-not-found

## Passos para Testar

1. Navegue até uma rota que contenha "teacher" no URL, como `/teacher`.
   - Verifique se a mensagem **"Ocorreu um erro de sistema 404"** é exibida.
2. Navegue até uma rota que contenha "student" no URL, como `/student`.
   - Verifique se a mensagem **"Link de convite indisponível"** é exibida junto ao parágrafo sugerindo que o estudante solicite um novo link ao professor.
3. Clique no botão "Voltar para a tela inicial" em ambas as rotas.
   - Verifique se o botão redireciona corretamente para a home (`/`).

## Checklist

- [x] A funcionalidade foi testada manualmente.
- [x] O código segue as boas práticas definidas.
- [x] Revisei as dependências e possíveis impactos no código existente.
